### PR TITLE
Added Target struct

### DIFF
--- a/actuary.go
+++ b/actuary.go
@@ -42,12 +42,14 @@ func (l *ContainerList) Running() bool {
 	return false
 }
 
+//Target stores information regarding the audit's target Docker server
 type Target struct {
 	Client     *client.Client
 	Info       types.Info
 	Containers ContainerList
 }
 
+//NewTarget initiates a new Target struct
 func NewTarget() (a Target, err error) {
 	a.Client, err = client.NewEnvClient()
 	if err != nil {

--- a/actuary.go
+++ b/actuary.go
@@ -1,7 +1,6 @@
 package actuary
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/docker/engine-api/client"
@@ -52,13 +51,11 @@ type Target struct {
 func NewTarget() (a Target, err error) {
 	a.Client, err = client.NewEnvClient()
 	if err != nil {
-		fmt.Printf("Unable to create Docker client")
-		return
+		log.Fatalf("unable to create Docker client: %v\n", err)
 	}
 	a.Info, err = a.Client.Info()
 	if err != nil {
-		fmt.Printf("Unable to create Docker client")
-		return
+		log.Fatalf("unable to fetch Docker daemon info: %v\n", err)
 	}
 	err = a.createContainerList()
 	return
@@ -68,7 +65,7 @@ func (t *Target) createContainerList() error {
 	opts := types.ContainerListOptions{All: false}
 	containers, err := t.Client.ContainerList(opts)
 	if err != nil {
-		log.Fatalf("Unable to get container list")
+		log.Fatalf("unable to get container list: %v\n", err)
 	}
 	for _, cont := range containers {
 		entry := new(Container)

--- a/actuary.go
+++ b/actuary.go
@@ -1,6 +1,7 @@
 package actuary
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/docker/engine-api/client"
@@ -42,19 +43,40 @@ func (l *ContainerList) Running() bool {
 	return false
 }
 
-func createContainerList(c *client.Client) (l ContainerList) {
+type Target struct {
+	Client     *client.Client
+	Info       types.Info
+	Containers ContainerList
+}
+
+func NewTarget() (a Target, err error) {
+	a.Client, err = client.NewEnvClient()
+	if err != nil {
+		fmt.Printf("Unable to create Docker client")
+		return
+	}
+	a.Info, err = a.Client.Info()
+	if err != nil {
+		fmt.Printf("Unable to create Docker client")
+		return
+	}
+	err = a.createContainerList()
+	return
+}
+
+func (t *Target) createContainerList() error {
 	opts := types.ContainerListOptions{All: false}
-	containers, err := c.ContainerList(opts)
+	containers, err := t.Client.ContainerList(opts)
 	if err != nil {
 		log.Fatalf("Unable to get container list")
 	}
 	for _, cont := range containers {
 		entry := new(Container)
-		inspectData, _ := c.ContainerInspect(cont.ID)
+		inspectData, _ := t.Client.ContainerInspect(cont.ID)
 		info := &ContainerInfo{inspectData}
 		entry.ID = cont.ID
 		entry.Info = *info
-		l = append(l, *entry)
+		t.Containers = append(t.Containers, *entry)
 	}
-	return
+	return nil
 }

--- a/actuary.go
+++ b/actuary.go
@@ -42,7 +42,7 @@ func (l *ContainerList) Running() bool {
 	return false
 }
 
-func CreateContainerList(c *client.Client) (l ContainerList) {
+func createContainerList(c *client.Client) (l ContainerList) {
 	opts := types.ContainerListOptions{All: false}
 	containers, err := c.ContainerList(opts)
 	if err != nil {

--- a/actuary_test-local.go
+++ b/actuary_test-local.go
@@ -18,16 +18,21 @@ var clientHeaders map[string]string
 func TestCreateContainerList(t *testing.T) {
 	clientHeaders = make(map[string]string)
 	clientHeaders["User-Agent"] = "engine-api-cli-1.0"
+	trgt := &Target{}
 	cli, err := client.NewClient("unix:///var/run/docker.sock", "v1.20", nil, clientHeaders)
 	if err != nil {
 		t.Errorf("Unable to connect to Docker daemon")
 	}
+	trgt.Client = cli
 	t.Log("Creating container list")
-	containers := CreateContainerList(cli)
-	if len(containers) != 1 {
-		t.Errorf("Expected 1 running container, got %d instead", len(containers))
+	err = trgt.createContainerList()
+	if err != nil {
+		t.Errorf("Unable to create container list: %s", err)
 	}
-	if containers[0].ID != contID {
-		t.Errorf("Expected %s, got %s instead", contID, containers[0].ID)
+	if len(trgt.Containers) != 1 {
+		t.Errorf("Expected 1 running container, got %d instead", len(trgt.Containers))
+	}
+	if trgt.Containers[0].ID != contID {
+		t.Errorf("Expected %s, got %s instead", contID, trgt.Containers[0].ID)
 	}
 }

--- a/checks/dockerconf.go
+++ b/checks/dockerconf.go
@@ -9,15 +9,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 )
 
-func RestrictNetTraffic(client *client.Client) (res Result) {
+func RestrictNetTraffic(t Target) (res Result) {
 	var netargs types.NetworkListOptions
 	res.Name = "2.1 Restrict network traffic between containers"
 
-	networks, err := client.NetworkList(netargs)
+	networks, err := t.Client.NetworkList(netargs)
 	if err != nil {
 		res.Skip("Cannot retrieve network list")
 		return
@@ -34,9 +33,8 @@ func RestrictNetTraffic(client *client.Client) (res Result) {
 	return
 }
 
-func CheckLoggingLevel(client *client.Client) (res Result) {
+func CheckLoggingLevel(t Target) (res Result) {
 	res.Name = "2.2 Set the logging level"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--log-level") {
@@ -52,9 +50,8 @@ func CheckLoggingLevel(client *client.Client) (res Result) {
 	return
 }
 
-func CheckIpTables(client *client.Client) (res Result) {
+func CheckIpTables(t Target) (res Result) {
 	res.Name = "2.3 Allow Docker to make changes to iptables"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--iptables") {
@@ -69,9 +66,8 @@ func CheckIpTables(client *client.Client) (res Result) {
 	return
 }
 
-func CheckInsecureRegistry(client *client.Client) (res Result) {
+func CheckInsecureRegistry(t Target) (res Result) {
 	res.Name = "2.4 Do not use insecure registries"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--insecure-registry") {
@@ -83,27 +79,22 @@ func CheckInsecureRegistry(client *client.Client) (res Result) {
 	return
 }
 
-func CheckAufsDriver(client *client.Client) (res Result) {
+func CheckAufsDriver(t Target) (res Result) {
 	res.Name = "2.5 Do not use the aufs storage driver"
-	info, err := client.Info()
-	if err != nil {
-		res.Skip("Unable to connect to Docker daemon")
-		return
-	}
+	info := t.Info
 	storageDriver := info.Driver
 
 	if storageDriver == "aufs" {
-		res.Status = "WARN"
+		res.Fail("")
 	} else {
 		res.Pass()
 	}
 	return
 }
 
-func CheckTLSAuth(client *client.Client) (res Result) {
+func CheckTLSAuth(t Target) (res Result) {
 	res.Name = "2.6 Configure TLS authentication for Docker daemon"
 	tlsOpts := []string{"--tlsverify", "--tlscacert", "--tlscert", "--tlskey"}
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		for i, tlsOpt := range tlsOpts {
@@ -122,9 +113,8 @@ func CheckTLSAuth(client *client.Client) (res Result) {
 	return
 }
 
-func CheckUlimit(client *client.Client) (res Result) {
+func CheckUlimit(t Target) (res Result) {
 	res.Name = "2.7 Set default ulimit as appropriate"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--default-ulimit") {
@@ -137,9 +127,8 @@ func CheckUlimit(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckUserNamespace(client *client.Client) (res Result) {
+func CheckUserNamespace(t Target) (res Result) {
 	res.Name = "2.8 Enable user namespace support"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--userns-remap") {
@@ -152,9 +141,8 @@ func CheckUserNamespace(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckDefaultCgroup(client *client.Client) (res Result) {
+func CheckDefaultCgroup(t Target) (res Result) {
 	res.Name = "2.9 Confirm default cgroup usage"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--cgroup-parent") {
@@ -167,9 +155,8 @@ func CheckDefaultCgroup(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckBaseDevice(client *client.Client) (res Result) {
+func CheckBaseDevice(t Target) (res Result) {
 	res.Name = "2.10 Do not change base device size until needed"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--storage-opt dm.basesize") {
@@ -182,9 +169,8 @@ func CheckBaseDevice(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckAuthPlugin(client *client.Client) (res Result) {
+func CheckAuthPlugin(t Target) (res Result) {
 	res.Name = "2.11 Use authorization plugin"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--authorization-plugin") {
@@ -196,9 +182,8 @@ func CheckAuthPlugin(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckCentralLogging(client *client.Client) (res Result) {
+func CheckCentralLogging(t Target) (res Result) {
 	res.Name = "2.12 Configure centralized and remote logging"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--log-driver") {
@@ -210,9 +195,8 @@ func CheckCentralLogging(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckLegacyRegistry(client *client.Client) (res Result) {
+func CheckLegacyRegistry(t Target) (res Result) {
 	res.Name = "2.13 Disable operations on legacy registry (v1)"
-
 	cmdLine, _ := GetProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--disable-legacy-registry") {

--- a/checks/dockerconf.go
+++ b/checks/dockerconf.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/diogomonica/actuary"
 	"github.com/docker/engine-api/types"
 )
 
-func RestrictNetTraffic(t Target) (res Result) {
+func RestrictNetTraffic(t actuary.Target) (res Result) {
 	var netargs types.NetworkListOptions
 	res.Name = "2.1 Restrict network traffic between containers"
 
@@ -33,9 +34,9 @@ func RestrictNetTraffic(t Target) (res Result) {
 	return
 }
 
-func CheckLoggingLevel(t Target) (res Result) {
+func CheckLoggingLevel(t actuary.Target) (res Result) {
 	res.Name = "2.2 Set the logging level"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--log-level") {
 			level := strings.Trim(strings.Split(arg, "=")[1], "\"")
@@ -50,9 +51,9 @@ func CheckLoggingLevel(t Target) (res Result) {
 	return
 }
 
-func CheckIpTables(t Target) (res Result) {
+func CheckIpTables(t actuary.Target) (res Result) {
 	res.Name = "2.3 Allow Docker to make changes to iptables"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--iptables") {
 			val := strings.Trim(strings.Split(arg, "=")[1], "\"")
@@ -66,9 +67,9 @@ func CheckIpTables(t Target) (res Result) {
 	return
 }
 
-func CheckInsecureRegistry(t Target) (res Result) {
+func CheckInsecureRegistry(t actuary.Target) (res Result) {
 	res.Name = "2.4 Do not use insecure registries"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--insecure-registry") {
 			res.Status = "WARN"
@@ -79,7 +80,7 @@ func CheckInsecureRegistry(t Target) (res Result) {
 	return
 }
 
-func CheckAufsDriver(t Target) (res Result) {
+func CheckAufsDriver(t actuary.Target) (res Result) {
 	res.Name = "2.5 Do not use the aufs storage driver"
 	info := t.Info
 	storageDriver := info.Driver
@@ -92,10 +93,10 @@ func CheckAufsDriver(t Target) (res Result) {
 	return
 }
 
-func CheckTLSAuth(t Target) (res Result) {
+func CheckTLSAuth(t actuary.Target) (res Result) {
 	res.Name = "2.6 Configure TLS authentication for Docker daemon"
 	tlsOpts := []string{"--tlsverify", "--tlscacert", "--tlscert", "--tlskey"}
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		for i, tlsOpt := range tlsOpts {
 			if strings.Contains(arg, tlsOpt) {
@@ -113,9 +114,9 @@ func CheckTLSAuth(t Target) (res Result) {
 	return
 }
 
-func CheckUlimit(t Target) (res Result) {
+func CheckUlimit(t actuary.Target) (res Result) {
 	res.Name = "2.7 Set default ulimit as appropriate"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--default-ulimit") {
 			res.Pass()
@@ -127,9 +128,9 @@ func CheckUlimit(t Target) (res Result) {
 	return res
 }
 
-func CheckUserNamespace(t Target) (res Result) {
+func CheckUserNamespace(t actuary.Target) (res Result) {
 	res.Name = "2.8 Enable user namespace support"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--userns-remap") {
 			res.Pass()
@@ -141,9 +142,9 @@ func CheckUserNamespace(t Target) (res Result) {
 	return res
 }
 
-func CheckDefaultCgroup(t Target) (res Result) {
+func CheckDefaultCgroup(t actuary.Target) (res Result) {
 	res.Name = "2.9 Confirm default cgroup usage"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--cgroup-parent") {
 			res.Pass()
@@ -155,9 +156,9 @@ func CheckDefaultCgroup(t Target) (res Result) {
 	return res
 }
 
-func CheckBaseDevice(t Target) (res Result) {
+func CheckBaseDevice(t actuary.Target) (res Result) {
 	res.Name = "2.10 Do not change base device size until needed"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--storage-opt dm.basesize") {
 			res.Pass()
@@ -169,9 +170,9 @@ func CheckBaseDevice(t Target) (res Result) {
 	return res
 }
 
-func CheckAuthPlugin(t Target) (res Result) {
+func CheckAuthPlugin(t actuary.Target) (res Result) {
 	res.Name = "2.11 Use authorization plugin"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--authorization-plugin") {
 			res.Pass()
@@ -182,9 +183,9 @@ func CheckAuthPlugin(t Target) (res Result) {
 	return res
 }
 
-func CheckCentralLogging(t Target) (res Result) {
+func CheckCentralLogging(t actuary.Target) (res Result) {
 	res.Name = "2.12 Configure centralized and remote logging"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--log-driver") {
 			res.Pass()
@@ -195,9 +196,9 @@ func CheckCentralLogging(t Target) (res Result) {
 	return res
 }
 
-func CheckLegacyRegistry(t Target) (res Result) {
+func CheckLegacyRegistry(t actuary.Target) (res Result) {
 	res.Name = "2.13 Disable operations on legacy registry (v1)"
-	cmdLine, _ := GetProcCmdline("docker")
+	cmdLine, _ := getProcCmdline("docker")
 	for _, arg := range cmdLine {
 		if strings.Contains(arg, "--disable-legacy-registry") {
 			res.Pass()

--- a/checks/dockerfiles.go
+++ b/checks/dockerfiles.go
@@ -11,9 +11,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/diogomonica/actuary"
 )
 
-func CheckServiceOwner(t Target) (res Result) {
+func CheckServiceOwner(t actuary.Target) (res Result) {
 	res.Name = "3.1 Verify that docker.service file ownership is set to root:root"
 	refUser := "root"
 	fileInfo, err := getSystemdFile("docker.service")
@@ -34,7 +36,7 @@ func CheckServiceOwner(t Target) (res Result) {
 	return
 }
 
-func CheckServicePerms(t Target) (res Result) {
+func CheckServicePerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.2 Verify that docker.service file permissions are set to
 		644 or more restrictive`
@@ -57,7 +59,7 @@ func CheckServicePerms(t Target) (res Result) {
 	return res
 }
 
-func CheckSocketOwner(t Target) (res Result) {
+func CheckSocketOwner(t actuary.Target) (res Result) {
 	res.Name = "3.3 Verify that docker.socket file ownership is set to root:root"
 	refUser := "root"
 	fileInfo, err := getSystemdFile("docker.socket")
@@ -78,7 +80,7 @@ func CheckSocketOwner(t Target) (res Result) {
 	return res
 }
 
-func CheckSocketPerms(t Target) (res Result) {
+func CheckSocketPerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.4 Verify that docker.socket file permissions are set to 644 or more
         restrictive`
@@ -101,7 +103,7 @@ func CheckSocketPerms(t Target) (res Result) {
 	return res
 }
 
-func CheckDockerDirOwner(t Target) (res Result) {
+func CheckDockerDirOwner(t actuary.Target) (res Result) {
 	res.Name = "3.5 Verify that /etc/docker directory ownership is set to root:root "
 	refUser := "root"
 	fileInfo, err := os.Stat("/etc/docker")
@@ -122,7 +124,7 @@ func CheckDockerDirOwner(t Target) (res Result) {
 	return res
 }
 
-func CheckDockerDirPerms(t Target) (res Result) {
+func CheckDockerDirPerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.6 Verify that /etc/docker directory permissions
 		are set to 755 or more restrictive`
@@ -145,7 +147,7 @@ func CheckDockerDirPerms(t Target) (res Result) {
 	return res
 }
 
-func CheckRegistryCertOwner(t Target) (res Result) {
+func CheckRegistryCertOwner(t actuary.Target) (res Result) {
 	var badFiles []string
 	res.Name = `3.7 Verify that registry certificate file ownership
 	 is set to root:root`
@@ -186,7 +188,7 @@ func CheckRegistryCertOwner(t Target) (res Result) {
 	return res
 }
 
-func CheckRegistryCertPerms(t Target) (res Result) {
+func CheckRegistryCertPerms(t actuary.Target) (res Result) {
 	var badFiles []string
 	var refPerms uint32
 	res.Name = `3.8 Verify that registry certificate file permissions
@@ -226,11 +228,11 @@ func CheckRegistryCertPerms(t Target) (res Result) {
 	return res
 }
 
-func CheckCACertOwner(t Target) (res Result) {
+func CheckCACertOwner(t actuary.Target) (res Result) {
 	res.Name = "3.9 Verify that TLS CA certificate file ownership is set to root:root"
 	refUser := "root"
-	dockerProc, _ := GetProcCmdline("docker")
-	_, certPath := GetCmdOption(dockerProc, "--tlscacert")
+	dockerProc, _ := getProcCmdline("docker")
+	_, certPath := getCmdOption(dockerProc, "--tlscacert")
 	fileInfo, err := os.Stat(certPath)
 	if os.IsNotExist(err) {
 		res.Skip("File could not be accessed")
@@ -249,13 +251,13 @@ func CheckCACertOwner(t Target) (res Result) {
 	return res
 }
 
-func CheckCACertPerms(t Target) (res Result) {
+func CheckCACertPerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.10 Verify that TLS CA certificate file permissions
 	are set to 444 or more restrictive`
 	refPerms = 0444
-	dockerProc, _ := GetProcCmdline("docker")
-	_, certPath := GetCmdOption(dockerProc, "--tlscacert")
+	dockerProc, _ := getProcCmdline("docker")
+	_, certPath := getCmdOption(dockerProc, "--tlscacert")
 	fileInfo, err := os.Stat(certPath)
 	if os.IsNotExist(err) {
 		res.Skip("File could not be accessed")
@@ -274,12 +276,12 @@ func CheckCACertPerms(t Target) (res Result) {
 	return res
 }
 
-func CheckServerCertOwner(t Target) (res Result) {
+func CheckServerCertOwner(t actuary.Target) (res Result) {
 	res.Name = `3.11 Verify that Docker server certificate file ownership is set to
         root:root`
 	refUser := "root"
-	dockerProc, _ := GetProcCmdline("docker")
-	_, certPath := GetCmdOption(dockerProc, "--tlscert")
+	dockerProc, _ := getProcCmdline("docker")
+	_, certPath := getCmdOption(dockerProc, "--tlscert")
 	fileInfo, err := os.Stat(certPath)
 	if os.IsNotExist(err) {
 		res.Skip("File could not be accessed")
@@ -298,13 +300,13 @@ func CheckServerCertOwner(t Target) (res Result) {
 	return res
 }
 
-func CheckServerCertPerms(t Target) (res Result) {
+func CheckServerCertPerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.12 Verify that Docker server certificate file permissions
 		are set to 444 or more restrictive`
 	refPerms = 0444
-	dockerProc, _ := GetProcCmdline("docker")
-	_, certPath := GetCmdOption(dockerProc, "--tlscert")
+	dockerProc, _ := getProcCmdline("docker")
+	_, certPath := getCmdOption(dockerProc, "--tlscert")
 	fileInfo, err := os.Stat(certPath)
 	if os.IsNotExist(err) {
 		res.Skip("File could not be accessed")
@@ -323,12 +325,12 @@ func CheckServerCertPerms(t Target) (res Result) {
 	return res
 }
 
-func CheckCertKeyOwner(t Target) (res Result) {
+func CheckCertKeyOwner(t actuary.Target) (res Result) {
 	res.Name = `3.13 Verify that Docker server certificate key file ownership is set to
         root:root`
 	refUser := "root"
-	dockerProc, _ := GetProcCmdline("docker")
-	_, certPath := GetCmdOption(dockerProc, "--tlskey")
+	dockerProc, _ := getProcCmdline("docker")
+	_, certPath := getCmdOption(dockerProc, "--tlskey")
 	fileInfo, err := os.Stat(certPath)
 	if os.IsNotExist(err) {
 		res.Skip("File could not be accessed")
@@ -347,13 +349,13 @@ func CheckCertKeyOwner(t Target) (res Result) {
 	return res
 }
 
-func CheckCertKeyPerms(t Target) (res Result) {
+func CheckCertKeyPerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.14 Verify that Docker server certificate key file
 	permissions are set to 400`
 	refPerms = 0400
-	dockerProc, _ := GetProcCmdline("docker")
-	_, certPath := GetCmdOption(dockerProc, "--tlskey")
+	dockerProc, _ := getProcCmdline("docker")
+	_, certPath := getCmdOption(dockerProc, "--tlskey")
 	fileInfo, err := os.Stat(certPath)
 	if os.IsNotExist(err) {
 		res.Skip("File could not be accessed")
@@ -372,7 +374,7 @@ func CheckCertKeyPerms(t Target) (res Result) {
 	return res
 }
 
-func CheckDockerSockOwner(t Target) (res Result) {
+func CheckDockerSockOwner(t actuary.Target) (res Result) {
 	res.Name = `3.15 Verify that Docker socket file ownership
 	is set to root:docker`
 	refUser := "root"
@@ -396,7 +398,7 @@ func CheckDockerSockOwner(t Target) (res Result) {
 	return res
 }
 
-func CheckDockerSockPerms(t Target) (res Result) {
+func CheckDockerSockPerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.16 Verify that Docker socket file permissions are set to 660`
 	refPerms = 0660
@@ -418,7 +420,7 @@ func CheckDockerSockPerms(t Target) (res Result) {
 	return res
 }
 
-func CheckDaemonJSONOwner(t Target) (res Result) {
+func CheckDaemonJSONOwner(t actuary.Target) (res Result) {
 	res.Name = `3.17 Verify that daemon.json file ownership is set to root:root`
 	refUser := "root"
 	refGroup := "root"
@@ -439,7 +441,7 @@ func CheckDaemonJSONOwner(t Target) (res Result) {
 	return
 }
 
-func CheckDaemonJSONPerms(t Target) (res Result) {
+func CheckDaemonJSONPerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.18 Verify that daemon.json file permissions are set to 644 or more
 restrictive`
@@ -460,7 +462,7 @@ restrictive`
 	return
 }
 
-func CheckDefaultOwner(t Target) (res Result) {
+func CheckDefaultOwner(t actuary.Target) (res Result) {
 	res.Name = `3.19 Verify that /etc/default/docker file ownership is set to root:root`
 	refUser := "root"
 	refGroup := "root"
@@ -481,7 +483,7 @@ func CheckDefaultOwner(t Target) (res Result) {
 	return
 }
 
-func CheckDefaultPerms(t Target) (res Result) {
+func CheckDefaultPerms(t actuary.Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.20 Verify that /etc/default/docker file permissions are set to 644 or
 more restrictive`

--- a/checks/dockerfiles.go
+++ b/checks/dockerfiles.go
@@ -11,11 +11,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-
-	"github.com/docker/engine-api/client"
 )
 
-func CheckServiceOwner(client *client.Client) (res Result) {
+func CheckServiceOwner(t Target) (res Result) {
 	res.Name = "3.1 Verify that docker.service file ownership is set to root:root"
 	refUser := "root"
 	fileInfo, err := getSystemdFile("docker.service")
@@ -36,7 +34,7 @@ func CheckServiceOwner(client *client.Client) (res Result) {
 	return
 }
 
-func CheckServicePerms(client *client.Client) (res Result) {
+func CheckServicePerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.2 Verify that docker.service file permissions are set to
 		644 or more restrictive`
@@ -59,7 +57,7 @@ func CheckServicePerms(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckSocketOwner(client *client.Client) (res Result) {
+func CheckSocketOwner(t Target) (res Result) {
 	res.Name = "3.3 Verify that docker.socket file ownership is set to root:root"
 	refUser := "root"
 	fileInfo, err := getSystemdFile("docker.socket")
@@ -80,7 +78,7 @@ func CheckSocketOwner(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckSocketPerms(client *client.Client) (res Result) {
+func CheckSocketPerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.4 Verify that docker.socket file permissions are set to 644 or more
         restrictive`
@@ -103,7 +101,7 @@ func CheckSocketPerms(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckDockerDirOwner(client *client.Client) (res Result) {
+func CheckDockerDirOwner(t Target) (res Result) {
 	res.Name = "3.5 Verify that /etc/docker directory ownership is set to root:root "
 	refUser := "root"
 	fileInfo, err := os.Stat("/etc/docker")
@@ -124,7 +122,7 @@ func CheckDockerDirOwner(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckDockerDirPerms(client *client.Client) (res Result) {
+func CheckDockerDirPerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.6 Verify that /etc/docker directory permissions
 		are set to 755 or more restrictive`
@@ -147,7 +145,7 @@ func CheckDockerDirPerms(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckRegistryCertOwner(client *client.Client) (res Result) {
+func CheckRegistryCertOwner(t Target) (res Result) {
 	var badFiles []string
 	res.Name = `3.7 Verify that registry certificate file ownership
 	 is set to root:root`
@@ -188,7 +186,7 @@ func CheckRegistryCertOwner(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckRegistryCertPerms(client *client.Client) (res Result) {
+func CheckRegistryCertPerms(t Target) (res Result) {
 	var badFiles []string
 	var refPerms uint32
 	res.Name = `3.8 Verify that registry certificate file permissions
@@ -228,7 +226,7 @@ func CheckRegistryCertPerms(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckCACertOwner(client *client.Client) (res Result) {
+func CheckCACertOwner(t Target) (res Result) {
 	res.Name = "3.9 Verify that TLS CA certificate file ownership is set to root:root"
 	refUser := "root"
 	dockerProc, _ := GetProcCmdline("docker")
@@ -251,7 +249,7 @@ func CheckCACertOwner(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckCACertPerms(client *client.Client) (res Result) {
+func CheckCACertPerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.10 Verify that TLS CA certificate file permissions
 	are set to 444 or more restrictive`
@@ -276,7 +274,7 @@ func CheckCACertPerms(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckServerCertOwner(client *client.Client) (res Result) {
+func CheckServerCertOwner(t Target) (res Result) {
 	res.Name = `3.11 Verify that Docker server certificate file ownership is set to
         root:root`
 	refUser := "root"
@@ -300,7 +298,7 @@ func CheckServerCertOwner(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckServerCertPerms(client *client.Client) (res Result) {
+func CheckServerCertPerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.12 Verify that Docker server certificate file permissions
 		are set to 444 or more restrictive`
@@ -325,7 +323,7 @@ func CheckServerCertPerms(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckCertKeyOwner(client *client.Client) (res Result) {
+func CheckCertKeyOwner(t Target) (res Result) {
 	res.Name = `3.13 Verify that Docker server certificate key file ownership is set to
         root:root`
 	refUser := "root"
@@ -349,7 +347,7 @@ func CheckCertKeyOwner(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckCertKeyPerms(client *client.Client) (res Result) {
+func CheckCertKeyPerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.14 Verify that Docker server certificate key file
 	permissions are set to 400`
@@ -374,7 +372,7 @@ func CheckCertKeyPerms(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckDockerSockOwner(client *client.Client) (res Result) {
+func CheckDockerSockOwner(t Target) (res Result) {
 	res.Name = `3.15 Verify that Docker socket file ownership
 	is set to root:docker`
 	refUser := "root"
@@ -398,7 +396,7 @@ func CheckDockerSockOwner(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckDockerSockPerms(client *client.Client) (res Result) {
+func CheckDockerSockPerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.16 Verify that Docker socket file permissions are set to 660`
 	refPerms = 0660
@@ -420,7 +418,7 @@ func CheckDockerSockPerms(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckDaemonJSONOwner(client *client.Client) (res Result) {
+func CheckDaemonJSONOwner(t Target) (res Result) {
 	res.Name = `3.17 Verify that daemon.json file ownership is set to root:root`
 	refUser := "root"
 	refGroup := "root"
@@ -441,7 +439,7 @@ func CheckDaemonJSONOwner(client *client.Client) (res Result) {
 	return
 }
 
-func CheckDaemonJSONPerms(client *client.Client) (res Result) {
+func CheckDaemonJSONPerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.18 Verify that daemon.json file permissions are set to 644 or more
 restrictive`
@@ -462,7 +460,7 @@ restrictive`
 	return
 }
 
-func CheckDefaultOwner(client *client.Client) (res Result) {
+func CheckDefaultOwner(t Target) (res Result) {
 	res.Name = `3.19 Verify that /etc/default/docker file ownership is set to root:root`
 	refUser := "root"
 	refGroup := "root"
@@ -483,7 +481,7 @@ func CheckDefaultOwner(client *client.Client) (res Result) {
 	return
 }
 
-func CheckDefaultPerms(client *client.Client) (res Result) {
+func CheckDefaultPerms(t Target) (res Result) {
 	var refPerms uint32
 	res.Name = `3.20 Verify that /etc/default/docker file permissions are set to 644 or
 more restrictive`

--- a/checks/dockerhost.go
+++ b/checks/dockerhost.go
@@ -14,13 +14,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/engine-api/client"
 	"github.com/drael/GOnetstat"
 	version "github.com/hashicorp/go-version"
 )
 
 //code borrowed from github.com/dockersecuritytools/batten
-func CheckSeparatePartion(client *client.Client) (res Result) {
+func CheckSeparatePartion(t Target) (res Result) {
 	res.Name = "1.1 Create a separate partition for containers"
 	fstab := "/etc/fstab"
 	bytes, err := ioutil.ReadFile(fstab)
@@ -41,13 +40,9 @@ func CheckSeparatePartion(client *client.Client) (res Result) {
 	return
 }
 
-func CheckKernelVersion(client *client.Client) (res Result) {
+func CheckKernelVersion(t Target) (res Result) {
 	res.Name = "1.2 Use the updated Linux Kernel"
-	info, err := client.Info()
-	if err != nil {
-		log.Fatalf("Could not retrieve info for Docker host")
-	}
-
+	info := t.Info
 	constraints, _ := version.NewConstraint(">= 3.10")
 	hostVersion, err := version.NewVersion(info.KernelVersion)
 	if err != nil {
@@ -67,7 +62,7 @@ func CheckKernelVersion(client *client.Client) (res Result) {
 	return
 }
 
-func CheckRunningServices(client *client.Client) (res Result) {
+func CheckRunningServices(t Target) (res Result) {
 	var openPorts []int64
 	res.Name = "1.4 Remove all non-essential services from the host"
 	tcpData := GOnetstat.Tcp()
@@ -80,10 +75,10 @@ func CheckRunningServices(client *client.Client) (res Result) {
 	return
 }
 
-func CheckDockerVersion(client *client.Client) (res Result) {
+func CheckDockerVersion(t Target) (res Result) {
 	res.Name = "1.5 Keep Docker up to date"
 	verConstr := os.Getenv("VERSION")
-	info, err := client.ServerVersion()
+	info, err := t.Client.ServerVersion()
 	if err != nil {
 		log.Fatalf("Could not retrieve info for Docker host")
 	}
@@ -99,7 +94,7 @@ func CheckDockerVersion(client *client.Client) (res Result) {
 	return
 }
 
-func CheckTrustedUsers(client *client.Client) (res Result) {
+func CheckTrustedUsers(t Target) (res Result) {
 	var trustedUsers []string
 	res.Name = "1.6 Only allow trusted users to control Docker daemon"
 	groupFile := "/etc/group"
@@ -133,7 +128,7 @@ func CheckTrustedUsers(client *client.Client) (res Result) {
 	return
 }
 
-func AuditDockerDaemon(client *client.Client) (res Result) {
+func AuditDockerDaemon(t Target) (res Result) {
 	res.Name = "1.7 Audit docker daemon"
 	err := checkAuditRule("/usr/bin/docker")
 	if err == nil {
@@ -146,7 +141,7 @@ func AuditDockerDaemon(client *client.Client) (res Result) {
 	return
 }
 
-func AuditLibDocker(client *client.Client) (res Result) {
+func AuditLibDocker(t Target) (res Result) {
 	res.Name = "1.8 Audit Docker files and directories - /var/lib/docker"
 	err := checkAuditRule("/var/lib/docker")
 	if err == nil {
@@ -159,7 +154,7 @@ func AuditLibDocker(client *client.Client) (res Result) {
 	return
 }
 
-func AuditEtcDocker(client *client.Client) (res Result) {
+func AuditEtcDocker(t Target) (res Result) {
 	res.Name = "1.9 Audit Docker files and directories - /etc/docker"
 	err := checkAuditRule("/etc/docker")
 	if err == nil {
@@ -172,7 +167,7 @@ func AuditEtcDocker(client *client.Client) (res Result) {
 	return
 }
 
-func AuditDockerService(client *client.Client) (res Result) {
+func AuditDockerService(t Target) (res Result) {
 	res.Name = "1.10 Audit Docker files and directories - docker.service"
 	err := checkAuditRule("/usr/lib/systemd/system/docker.service")
 	if err == nil {
@@ -185,7 +180,7 @@ func AuditDockerService(client *client.Client) (res Result) {
 	return
 }
 
-func AuditDockerSocket(client *client.Client) (res Result) {
+func AuditDockerSocket(t Target) (res Result) {
 	res.Name = "1.11 Audit Docker files and directories - docker.socket"
 	err := checkAuditRule("/usr/lib/systemd/system/docker.socket")
 	if err == nil {
@@ -198,7 +193,7 @@ func AuditDockerSocket(client *client.Client) (res Result) {
 	return
 }
 
-func AuditDockerDefault(client *client.Client) (res Result) {
+func AuditDockerDefault(t Target) (res Result) {
 	res.Name = "1.12 Audit Docker files and directories - /etc/default/docker"
 	err := checkAuditRule("/etc/default/docker")
 	if err == nil {
@@ -211,7 +206,7 @@ func AuditDockerDefault(client *client.Client) (res Result) {
 	return
 }
 
-func AuditDaemonJSON(client *client.Client) (res Result) {
+func AuditDaemonJSON(t Target) (res Result) {
 	res.Name = "1.13 Audit Docker files and directories - /etc/docker/daemon.json"
 	err := checkAuditRule("/etc/docker/daemon.json")
 	if err == nil {
@@ -224,7 +219,7 @@ func AuditDaemonJSON(client *client.Client) (res Result) {
 	return
 }
 
-func AuditContainerd(client *client.Client) (res Result) {
+func AuditContainerd(t Target) (res Result) {
 	res.Name = "1.14 Audit Docker files and directories - /usr/bin/docker-containerd"
 	err := checkAuditRule("/usr/bin/docker-containerd")
 	if err == nil {
@@ -237,7 +232,7 @@ func AuditContainerd(client *client.Client) (res Result) {
 	return
 }
 
-func AuditRunc(client *client.Client) (res Result) {
+func AuditRunc(t Target) (res Result) {
 	res.Name = "1.15 Audit Docker files and directories - /usr/bin/docker-runc"
 	err := checkAuditRule("/usr/bin/docker-runc")
 	if err == nil {

--- a/checks/dockerhost.go
+++ b/checks/dockerhost.go
@@ -14,12 +14,13 @@ import (
 	"os"
 	"strings"
 
+	"github.com/diogomonica/actuary"
 	"github.com/drael/GOnetstat"
 	version "github.com/hashicorp/go-version"
 )
 
 //code borrowed from github.com/dockersecuritytools/batten
-func CheckSeparatePartion(t Target) (res Result) {
+func CheckSeparatePartion(t actuary.Target) (res Result) {
 	res.Name = "1.1 Create a separate partition for containers"
 	fstab := "/etc/fstab"
 	bytes, err := ioutil.ReadFile(fstab)
@@ -40,7 +41,7 @@ func CheckSeparatePartion(t Target) (res Result) {
 	return
 }
 
-func CheckKernelVersion(t Target) (res Result) {
+func CheckKernelVersion(t actuary.Target) (res Result) {
 	res.Name = "1.2 Use the updated Linux Kernel"
 	info := t.Info
 	constraints, _ := version.NewConstraint(">= 3.10")
@@ -62,7 +63,7 @@ func CheckKernelVersion(t Target) (res Result) {
 	return
 }
 
-func CheckRunningServices(t Target) (res Result) {
+func CheckRunningServices(t actuary.Target) (res Result) {
 	var openPorts []int64
 	res.Name = "1.4 Remove all non-essential services from the host"
 	tcpData := GOnetstat.Tcp()
@@ -75,7 +76,7 @@ func CheckRunningServices(t Target) (res Result) {
 	return
 }
 
-func CheckDockerVersion(t Target) (res Result) {
+func CheckDockerVersion(t actuary.Target) (res Result) {
 	res.Name = "1.5 Keep Docker up to date"
 	verConstr := os.Getenv("VERSION")
 	info, err := t.Client.ServerVersion()
@@ -94,7 +95,7 @@ func CheckDockerVersion(t Target) (res Result) {
 	return
 }
 
-func CheckTrustedUsers(t Target) (res Result) {
+func CheckTrustedUsers(t actuary.Target) (res Result) {
 	var trustedUsers []string
 	res.Name = "1.6 Only allow trusted users to control Docker daemon"
 	groupFile := "/etc/group"
@@ -128,7 +129,7 @@ func CheckTrustedUsers(t Target) (res Result) {
 	return
 }
 
-func AuditDockerDaemon(t Target) (res Result) {
+func AuditDockerDaemon(t actuary.Target) (res Result) {
 	res.Name = "1.7 Audit docker daemon"
 	err := checkAuditRule("/usr/bin/docker")
 	if err == nil {
@@ -141,7 +142,7 @@ func AuditDockerDaemon(t Target) (res Result) {
 	return
 }
 
-func AuditLibDocker(t Target) (res Result) {
+func AuditLibDocker(t actuary.Target) (res Result) {
 	res.Name = "1.8 Audit Docker files and directories - /var/lib/docker"
 	err := checkAuditRule("/var/lib/docker")
 	if err == nil {
@@ -154,7 +155,7 @@ func AuditLibDocker(t Target) (res Result) {
 	return
 }
 
-func AuditEtcDocker(t Target) (res Result) {
+func AuditEtcDocker(t actuary.Target) (res Result) {
 	res.Name = "1.9 Audit Docker files and directories - /etc/docker"
 	err := checkAuditRule("/etc/docker")
 	if err == nil {
@@ -167,7 +168,7 @@ func AuditEtcDocker(t Target) (res Result) {
 	return
 }
 
-func AuditDockerService(t Target) (res Result) {
+func AuditDockerService(t actuary.Target) (res Result) {
 	res.Name = "1.10 Audit Docker files and directories - docker.service"
 	err := checkAuditRule("/usr/lib/systemd/system/docker.service")
 	if err == nil {
@@ -180,7 +181,7 @@ func AuditDockerService(t Target) (res Result) {
 	return
 }
 
-func AuditDockerSocket(t Target) (res Result) {
+func AuditDockerSocket(t actuary.Target) (res Result) {
 	res.Name = "1.11 Audit Docker files and directories - docker.socket"
 	err := checkAuditRule("/usr/lib/systemd/system/docker.socket")
 	if err == nil {
@@ -193,7 +194,7 @@ func AuditDockerSocket(t Target) (res Result) {
 	return
 }
 
-func AuditDockerDefault(t Target) (res Result) {
+func AuditDockerDefault(t actuary.Target) (res Result) {
 	res.Name = "1.12 Audit Docker files and directories - /etc/default/docker"
 	err := checkAuditRule("/etc/default/docker")
 	if err == nil {
@@ -206,7 +207,7 @@ func AuditDockerDefault(t Target) (res Result) {
 	return
 }
 
-func AuditDaemonJSON(t Target) (res Result) {
+func AuditDaemonJSON(t actuary.Target) (res Result) {
 	res.Name = "1.13 Audit Docker files and directories - /etc/docker/daemon.json"
 	err := checkAuditRule("/etc/docker/daemon.json")
 	if err == nil {
@@ -219,7 +220,7 @@ func AuditDaemonJSON(t Target) (res Result) {
 	return
 }
 
-func AuditContainerd(t Target) (res Result) {
+func AuditContainerd(t actuary.Target) (res Result) {
 	res.Name = "1.14 Audit Docker files and directories - /usr/bin/docker-containerd"
 	err := checkAuditRule("/usr/bin/docker-containerd")
 	if err == nil {
@@ -232,7 +233,7 @@ func AuditContainerd(t Target) (res Result) {
 	return
 }
 
-func AuditRunc(t Target) (res Result) {
+func AuditRunc(t actuary.Target) (res Result) {
 	res.Name = "1.15 Audit Docker files and directories - /usr/bin/docker-runc"
 	err := checkAuditRule("/usr/bin/docker-runc")
 	if err == nil {

--- a/checks/images.go
+++ b/checks/images.go
@@ -12,9 +12,11 @@ package checks
 import (
 	"fmt"
 	"os"
+
+	"github.com/diogomonica/actuary"
 )
 
-func CheckContainerUser(t Target) (res Result) {
+func CheckContainerUser(t actuary.Target) (res Result) {
 	var rootContainers []string
 	res.Name = "4.1 Create a user for the container"
 	containers := t.Containers
@@ -39,7 +41,7 @@ func CheckContainerUser(t Target) (res Result) {
 	return res
 }
 
-func CheckContentTrust(t Target) (res Result) {
+func CheckContentTrust(t actuary.Target) (res Result) {
 	res.Name = "4.5 Enable Content trust for Docker"
 	trust := os.Getenv("DOCKER_CONTENT_TRUST")
 	if trust == "1" {

--- a/checks/images.go
+++ b/checks/images.go
@@ -12,15 +12,12 @@ package checks
 import (
 	"fmt"
 	"os"
-
-	"github.com/diogomonica/actuary"
-	"github.com/docker/engine-api/client"
 )
 
-func CheckContainerUser(client *client.Client) (res Result) {
+func CheckContainerUser(t Target) (res Result) {
 	var rootContainers []string
 	res.Name = "4.1 Create a user for the container"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -42,7 +39,7 @@ func CheckContainerUser(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckContentTrust(client *client.Client) (res Result) {
+func CheckContentTrust(t Target) (res Result) {
 	res.Name = "4.5 Enable Content trust for Docker"
 	trust := os.Getenv("DOCKER_CONTENT_TRUST")
 	if trust == "1" {

--- a/checks/runtime.go
+++ b/checks/runtime.go
@@ -9,11 +9,13 @@ package checks
 import (
 	"fmt"
 
+	"github.com/diogomonica/actuary"
+
 	"strconv"
 	"strings"
 )
 
-func CheckAppArmor(t Target) (res Result) {
+func CheckAppArmor(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.1 Verify AppArmor Profile, if applicable"
 	containers := t.Containers
@@ -36,7 +38,7 @@ func CheckAppArmor(t Target) (res Result) {
 	return
 }
 
-func CheckSELinux(t Target) (res Result) {
+func CheckSELinux(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.1 Verify AppArmor Profile, if applicable"
 	containers := t.Containers
@@ -59,7 +61,7 @@ func CheckSELinux(t Target) (res Result) {
 	return
 }
 
-func CheckKernelCapabilities(t Target) (res Result) {
+func CheckKernelCapabilities(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.3 Restrict Linux Kernel Capabilities within containers"
 	containers := t.Containers
@@ -82,7 +84,7 @@ func CheckKernelCapabilities(t Target) (res Result) {
 	return
 }
 
-func CheckPrivContainers(t Target) (res Result) {
+func CheckPrivContainers(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.4 Do not use privileged containers"
 	containers := t.Containers
@@ -105,7 +107,7 @@ func CheckPrivContainers(t Target) (res Result) {
 	return
 }
 
-func CheckSensitiveDirs(t Target) (res Result) {
+func CheckSensitiveDirs(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.5 Do not mount sensitive host system directories on containers "
 	sensitiveDirs := []string{"/dev", "/etc", "/lib", "/proc", "/sys", "/usr"}
@@ -135,7 +137,7 @@ func CheckSensitiveDirs(t Target) (res Result) {
 	return
 }
 
-func CheckSSHRunning(t Target) (res Result) {
+func CheckSSHRunning(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.6 Do not run ssh within containers"
 	containers := t.Containers
@@ -164,7 +166,7 @@ func CheckSSHRunning(t Target) (res Result) {
 	return
 }
 
-func CheckPrivilegedPorts(t Target) (res Result) {
+func CheckPrivilegedPorts(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.7 Do not map privileged ports within containers"
 	containers := t.Containers
@@ -194,7 +196,7 @@ func CheckPrivilegedPorts(t Target) (res Result) {
 	return
 }
 
-func CheckNeededPorts(t Target) (res Result) {
+func CheckNeededPorts(t actuary.Target) (res Result) {
 	var containerPort map[string][]string
 	containerPort = make(map[string][]string)
 	res.Name = "5.8 Open only needed ports on container"
@@ -217,7 +219,7 @@ func CheckNeededPorts(t Target) (res Result) {
 	return res
 }
 
-func CheckHostNetworkMode(t Target) (res Result) {
+func CheckHostNetworkMode(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.9 Do not use host network mode on container"
 	containers := t.Containers
@@ -243,7 +245,7 @@ func CheckHostNetworkMode(t Target) (res Result) {
 	return
 }
 
-func CheckMemoryLimits(t Target) (res Result) {
+func CheckMemoryLimits(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.10 Limit memory usage for container"
 	containers := t.Containers
@@ -268,7 +270,7 @@ func CheckMemoryLimits(t Target) (res Result) {
 	return
 }
 
-func CheckCPUShares(t Target) (res Result) {
+func CheckCPUShares(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.11 Set container CPU priority appropriately"
 	containers := t.Containers
@@ -293,7 +295,7 @@ func CheckCPUShares(t Target) (res Result) {
 	return
 }
 
-func CheckReadonlyRoot(t Target) (res Result) {
+func CheckReadonlyRoot(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.12 Mount container's root filesystem as read only"
 	containers := t.Containers
@@ -317,7 +319,7 @@ func CheckReadonlyRoot(t Target) (res Result) {
 	return
 }
 
-func CheckBindHostInterface(t Target) (res Result) {
+func CheckBindHostInterface(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.13 Bind incoming container traffic to a specific host interface"
 	containers := t.Containers
@@ -345,7 +347,7 @@ func CheckBindHostInterface(t Target) (res Result) {
 	return
 }
 
-func CheckRestartPolicy(t Target) (res Result) {
+func CheckRestartPolicy(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.14 Set the 'on-failure' container restart policy to 5"
 	containers := t.Containers
@@ -370,7 +372,7 @@ func CheckRestartPolicy(t Target) (res Result) {
 	return
 }
 
-func CheckHostNamespace(t Target) (res Result) {
+func CheckHostNamespace(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.15 Do not share the host's process namespace"
 	containers := t.Containers
@@ -395,7 +397,7 @@ func CheckHostNamespace(t Target) (res Result) {
 	return
 }
 
-func CheckIPCNamespace(t Target) (res Result) {
+func CheckIPCNamespace(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.16 Do not share the host's IPC namespace"
 	containers := t.Containers
@@ -421,7 +423,7 @@ func CheckIPCNamespace(t Target) (res Result) {
 	return
 }
 
-func CheckHostDevices(t Target) (res Result) {
+func CheckHostDevices(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.17 Do not directly expose host devices to containers"
 	containers := t.Containers
@@ -448,7 +450,7 @@ func CheckHostDevices(t Target) (res Result) {
 	return
 }
 
-func CheckDefaultUlimit(t Target) (res Result) {
+func CheckDefaultUlimit(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.18 Override default ulimit at runtime only if needed "
 	containers := t.Containers
@@ -474,7 +476,7 @@ func CheckDefaultUlimit(t Target) (res Result) {
 	return
 }
 
-func CheckMountPropagation(t Target) (res Result) {
+func CheckMountPropagation(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.19 Do not set mount propagation mode to shared"
 	containers := t.Containers
@@ -501,7 +503,7 @@ func CheckMountPropagation(t Target) (res Result) {
 	return
 }
 
-func CheckUTSnamespace(t Target) (res Result) {
+func CheckUTSnamespace(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.20 Do not share the host's UTS namespace"
 	containers := t.Containers
@@ -527,7 +529,7 @@ func CheckUTSnamespace(t Target) (res Result) {
 	return
 }
 
-func CheckSeccompProfile(t Target) (res Result) {
+func CheckSeccompProfile(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.21 Do not disable default seccomp profile"
 	containers := t.Containers
@@ -552,7 +554,7 @@ func CheckSeccompProfile(t Target) (res Result) {
 	return
 }
 
-func CheckCgroupUsage(t Target) (res Result) {
+func CheckCgroupUsage(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.24 Confirm cgroup usage"
 	containers := t.Containers
@@ -577,7 +579,7 @@ func CheckCgroupUsage(t Target) (res Result) {
 	return
 }
 
-func CheckAdditionalPrivs(t Target) (res Result) {
+func CheckAdditionalPrivs(t actuary.Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.25 Restrict container from acquiring additional privileges"
 	containers := t.Containers

--- a/checks/runtime.go
+++ b/checks/runtime.go
@@ -8,6 +8,7 @@ package checks
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/diogomonica/actuary"
 
@@ -147,7 +148,10 @@ func CheckSSHRunning(t actuary.Target) (res Result) {
 		return
 	}
 	for _, container := range containers {
-		procs, _ := t.Client.ContainerTop(container.ID, []string{})
+		procs, err := t.Client.ContainerTop(container.ID, []string{})
+		if err != nil {
+			log.Printf("unable to retrieve proc list for container %s: %v", container.ID, err)
+		}
 		//proc fields are [UID PID PPID C STIME TTY TIME CMD]
 		for _, proc := range procs.Processes {
 			procname := proc[7]

--- a/checks/runtime.go
+++ b/checks/runtime.go
@@ -9,17 +9,14 @@ package checks
 import (
 	"fmt"
 
-	"github.com/diogomonica/actuary"
-	"github.com/docker/engine-api/client"
-
 	"strconv"
 	"strings"
 )
 
-func CheckAppArmor(client *client.Client) (res Result) {
+func CheckAppArmor(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.1 Verify AppArmor Profile, if applicable"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -39,10 +36,10 @@ func CheckAppArmor(client *client.Client) (res Result) {
 	return
 }
 
-func CheckSELinux(client *client.Client) (res Result) {
+func CheckSELinux(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.1 Verify AppArmor Profile, if applicable"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -62,10 +59,10 @@ func CheckSELinux(client *client.Client) (res Result) {
 	return
 }
 
-func CheckKernelCapabilities(client *client.Client) (res Result) {
+func CheckKernelCapabilities(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.3 Restrict Linux Kernel Capabilities within containers"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -85,10 +82,10 @@ func CheckKernelCapabilities(client *client.Client) (res Result) {
 	return
 }
 
-func CheckPrivContainers(client *client.Client) (res Result) {
+func CheckPrivContainers(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.4 Do not use privileged containers"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -108,11 +105,11 @@ func CheckPrivContainers(client *client.Client) (res Result) {
 	return
 }
 
-func CheckSensitiveDirs(client *client.Client) (res Result) {
+func CheckSensitiveDirs(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.5 Do not mount sensitive host system directories on containers "
 	sensitiveDirs := []string{"/dev", "/etc", "/lib", "/proc", "/sys", "/usr"}
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 
 	if !containers.Running() {
 		res.Skip("No running containers")
@@ -138,17 +135,17 @@ func CheckSensitiveDirs(client *client.Client) (res Result) {
 	return
 }
 
-func CheckSSHRunning(client *client.Client) (res Result) {
+func CheckSSHRunning(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.6 Do not run ssh within containers"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
 	}
 	for _, container := range containers {
-		procs, _ := client.ContainerTop(container.ID, []string{})
+		procs, _ := t.Client.ContainerTop(container.ID, []string{})
 		//proc fields are [UID PID PPID C STIME TTY TIME CMD]
 		for _, proc := range procs.Processes {
 			procname := proc[7]
@@ -167,10 +164,10 @@ func CheckSSHRunning(client *client.Client) (res Result) {
 	return
 }
 
-func CheckPrivilegedPorts(client *client.Client) (res Result) {
+func CheckPrivilegedPorts(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.7 Do not map privileged ports within containers"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -197,11 +194,11 @@ func CheckPrivilegedPorts(client *client.Client) (res Result) {
 	return
 }
 
-func CheckNeededPorts(client *client.Client) (res Result) {
+func CheckNeededPorts(t Target) (res Result) {
 	var containerPort map[string][]string
 	containerPort = make(map[string][]string)
 	res.Name = "5.8 Open only needed ports on container"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -220,18 +217,17 @@ func CheckNeededPorts(client *client.Client) (res Result) {
 	return res
 }
 
-func CheckHostNetworkMode(client *client.Client) (res Result) {
+func CheckHostNetworkMode(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.9 Do not use host network mode on container"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
 	}
 
 	for _, container := range containers {
-		info, _ := client.ContainerInspect(container.ID)
-		mode := info.HostConfig.NetworkMode
+		mode := container.Info.HostConfig.NetworkMode
 		if mode == "host" {
 			badContainers = append(badContainers, container.ID)
 		}
@@ -247,17 +243,16 @@ func CheckHostNetworkMode(client *client.Client) (res Result) {
 	return
 }
 
-func CheckMemoryLimits(client *client.Client) (res Result) {
+func CheckMemoryLimits(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.10 Limit memory usage for container"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
 	}
 	for _, container := range containers {
-		info, _ := client.ContainerInspect(container.ID)
-		mem := info.HostConfig.Memory
+		mem := container.Info.HostConfig.Memory
 		if mem == 0 {
 			badContainers = append(badContainers, container.ID)
 		}
@@ -273,10 +268,10 @@ func CheckMemoryLimits(client *client.Client) (res Result) {
 	return
 }
 
-func CheckCPUShares(client *client.Client) (res Result) {
+func CheckCPUShares(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.11 Set container CPU priority appropriately"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -298,10 +293,10 @@ func CheckCPUShares(client *client.Client) (res Result) {
 	return
 }
 
-func CheckReadonlyRoot(client *client.Client) (res Result) {
+func CheckReadonlyRoot(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.12 Mount container's root filesystem as read only"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -322,10 +317,10 @@ func CheckReadonlyRoot(client *client.Client) (res Result) {
 	return
 }
 
-func CheckBindHostInterface(client *client.Client) (res Result) {
+func CheckBindHostInterface(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.13 Bind incoming container traffic to a specific host interface"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -350,10 +345,10 @@ func CheckBindHostInterface(client *client.Client) (res Result) {
 	return
 }
 
-func CheckRestartPolicy(client *client.Client) (res Result) {
+func CheckRestartPolicy(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.14 Set the 'on-failure' container restart policy to 5"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -375,10 +370,10 @@ func CheckRestartPolicy(client *client.Client) (res Result) {
 	return
 }
 
-func CheckHostNamespace(client *client.Client) (res Result) {
+func CheckHostNamespace(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.15 Do not share the host's process namespace"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -400,10 +395,10 @@ func CheckHostNamespace(client *client.Client) (res Result) {
 	return
 }
 
-func CheckIPCNamespace(client *client.Client) (res Result) {
+func CheckIPCNamespace(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.16 Do not share the host's IPC namespace"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -426,10 +421,10 @@ func CheckIPCNamespace(client *client.Client) (res Result) {
 	return
 }
 
-func CheckHostDevices(client *client.Client) (res Result) {
+func CheckHostDevices(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.17 Do not directly expose host devices to containers"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -453,10 +448,10 @@ func CheckHostDevices(client *client.Client) (res Result) {
 	return
 }
 
-func CheckDefaultUlimit(client *client.Client) (res Result) {
+func CheckDefaultUlimit(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.18 Override default ulimit at runtime only if needed "
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -479,10 +474,10 @@ func CheckDefaultUlimit(client *client.Client) (res Result) {
 	return
 }
 
-func CheckMountPropagation(client *client.Client) (res Result) {
+func CheckMountPropagation(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.19 Do not set mount propagation mode to shared"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -506,10 +501,10 @@ func CheckMountPropagation(client *client.Client) (res Result) {
 	return
 }
 
-func CheckUTSnamespace(client *client.Client) (res Result) {
+func CheckUTSnamespace(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.20 Do not share the host's UTS namespace"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -532,10 +527,10 @@ func CheckUTSnamespace(client *client.Client) (res Result) {
 	return
 }
 
-func CheckSeccompProfile(client *client.Client) (res Result) {
+func CheckSeccompProfile(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.21 Do not disable default seccomp profile"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -557,10 +552,10 @@ func CheckSeccompProfile(client *client.Client) (res Result) {
 	return
 }
 
-func CheckCgroupUsage(client *client.Client) (res Result) {
+func CheckCgroupUsage(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.24 Confirm cgroup usage"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return
@@ -582,10 +577,10 @@ func CheckCgroupUsage(client *client.Client) (res Result) {
 	return
 }
 
-func CheckAdditionalPrivs(client *client.Client) (res Result) {
+func CheckAdditionalPrivs(t Target) (res Result) {
 	var badContainers []string
 	res.Name = "5.25 Restrict container from acquiring additional privileges"
-	containers := actuary.CreateContainerList(client)
+	containers := t.Containers
 	if !containers.Running() {
 		res.Skip("No running containers")
 		return

--- a/checks/secops.go
+++ b/checks/secops.go
@@ -11,10 +11,11 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/diogomonica/actuary"
 	"github.com/docker/engine-api/types"
 )
 
-func CheckImageSprawl(t Target) (res Result) {
+func CheckImageSprawl(t actuary.Target) (res Result) {
 	var allImageIDs []string
 	var runImageIDs []string
 	res.Name = "6.4 Avoid image sprawl"
@@ -51,7 +52,7 @@ func CheckImageSprawl(t Target) (res Result) {
 	return
 }
 
-func CheckContainerSprawl(t Target) (res Result) {
+func CheckContainerSprawl(t actuary.Target) (res Result) {
 	var diff int
 	res.Name = "6.5 Avoid container sprawl"
 	options := types.ContainerListOptions{All: false}

--- a/checks/secops.go
+++ b/checks/secops.go
@@ -11,16 +11,15 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 )
 
-func CheckImageSprawl(client *client.Client) (res Result) {
+func CheckImageSprawl(t Target) (res Result) {
 	var allImageIDs []string
 	var runImageIDs []string
 	res.Name = "6.4 Avoid image sprawl"
 	imgOpts := types.ImageListOptions{All: false}
-	allImages, err := client.ImageList(imgOpts)
+	allImages, err := t.Client.ImageList(imgOpts)
 	if err != nil {
 		res.Skip("Unable to retrieve image list")
 		return
@@ -30,7 +29,7 @@ func CheckImageSprawl(client *client.Client) (res Result) {
 	}
 
 	conOpts := types.ContainerListOptions{All: true}
-	containers, err := client.ContainerList(conOpts)
+	containers, err := t.Client.ContainerList(conOpts)
 	if err != nil {
 		res.Skip("Unable to retrieve container list")
 		return
@@ -52,13 +51,13 @@ func CheckImageSprawl(client *client.Client) (res Result) {
 	return
 }
 
-func CheckContainerSprawl(client *client.Client) (res Result) {
+func CheckContainerSprawl(t Target) (res Result) {
 	var diff int
 	res.Name = "6.5 Avoid container sprawl"
 	options := types.ContainerListOptions{All: false}
-	runContainers, err := client.ContainerList(options)
+	runContainers, err := t.Client.ContainerList(options)
 	options = types.ContainerListOptions{All: true}
-	allContainers, err := client.ContainerList(options)
+	allContainers, err := t.Client.ContainerList(options)
 	if err != nil {
 		log.Printf("Unable to get container list")
 		return res

--- a/cmd/actuary/main.go
+++ b/cmd/actuary/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/diogomonica/actuary"
 	"github.com/diogomonica/actuary/checks"
 	"github.com/diogomonica/actuary/oututils"
 	"github.com/diogomonica/actuary/profileutils"
@@ -41,7 +42,7 @@ func main() {
 	} else {
 		os.Setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
 	}
-	trgt, err := checks.NewTarget()
+	trgt, err := actuary.NewTarget()
 	if err != nil {
 		log.Fatalf("Unable to connect to Docker daemon: %s", err)
 	}

--- a/cmd/actuary/main.go
+++ b/cmd/actuary/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/diogomonica/actuary/checks"
 	"github.com/diogomonica/actuary/oututils"
 	"github.com/diogomonica/actuary/profileutils"
-	"github.com/docker/engine-api/client"
 )
 
 var profile = flag.String("profile", "", "Actuary profile file path")
@@ -42,7 +41,7 @@ func main() {
 	} else {
 		os.Setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
 	}
-	cli, err := client.NewEnvClient()
+	trgt, err := checks.NewTarget()
 	if err != nil {
 		log.Fatalf("Unable to connect to Docker daemon: %s", err)
 	}
@@ -72,7 +71,7 @@ func main() {
 		//cross-reference checks
 		for _, check := range checks {
 			if _, ok := actions[check]; ok {
-				res := actions[check](cli)
+				res := actions[check](trgt)
 				results = append(results, res)
 				oututils.ConsolePrint(res)
 			} else {


### PR DESCRIPTION
This pull request addresses #5. Until now every check which required info from the Docker server had to make one or more API calls. I have added a new struct, named `Target` which is initialized when actuary starts. 
The struct instance stores a pointer to the engine-api client, a list of containers along with their `docker inspect` output and the output of [client.Info()](https://godoc.org/github.com/docker/engine-api/client#Client.Info). 
This information can be used by every check which significantly reduces API calls (making Actuary faster and more reliable) during an audit and saves us a few lines of code.

cc @diogomonica 
